### PR TITLE
feat: add optional host to Anthropic settings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = ee.carlrobert
 pluginName = CodeGPT
 pluginRepositoryUrl = https://github.com/carlrobertoh/CodeGPT
 # SemVer format -> https://semver.org
-pluginVersion = 2.16.2
+pluginVersion = 2.16.2-SNAPSHOT
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 241.1

--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionClientProvider.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionClientProvider.java
@@ -39,9 +39,12 @@ public class CompletionClientProvider {
   }
 
   public static ClaudeClient getClaudeClient() {
+    final ClaudeClient.Builder builder = new ClaudeClient.Builder(getCredential(CredentialKey.ANTHROPIC_API_KEY), AnthropicSettings.getCurrentState().getApiVersion());
+    if (AnthropicSettings.getCurrentState().getHost() != null && !AnthropicSettings.getCurrentState().getHost().isEmpty()) {
+        builder.setHost(AnthropicSettings.getCurrentState().getHost());
+    }
     return new ClaudeClient(
-        getCredential(CredentialKey.ANTHROPIC_API_KEY),
-        AnthropicSettings.getCurrentState().getApiVersion(),
+        builder,
         getDefaultClientBuilder());
   }
 

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettingsForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettingsForm.java
@@ -19,6 +19,7 @@ public class AnthropicSettingsForm {
   private final JBPasswordField apiKeyField;
   private final JBTextField apiVersionField;
   private final JBTextField modelField;
+  private final JBTextField hostField;
 
   public AnthropicSettingsForm(AnthropicSettingsState settings) {
     apiKeyField = new JBPasswordField();
@@ -29,6 +30,7 @@ public class AnthropicSettingsForm {
     });
     apiVersionField = new JBTextField(settings.getApiVersion(), 35);
     modelField = new JBTextField(settings.getModel(), 35);
+    hostField = new JBTextField(settings.getHost(), 35);
   }
 
   public JPanel getForm() {
@@ -51,6 +53,11 @@ public class AnthropicSettingsForm {
                 .withComment(CodeGPTBundle.get(
                     "settingsConfigurable.service.anthropic.model.comment"))
                 .resizeX(false))
+            .add(UI.PanelFactory.panel(hostField)
+                .withLabel(CodeGPTBundle.get("settingsConfigurable.service.custom.anthropic.url.label"))
+                .withComment(CodeGPTBundle.get(
+                    "settingsConfigurable.service.anthropic.url.comment"))
+                .resizeX(false))
             .createPanel())
         .addComponentFillVertically(new JPanel(), 0)
         .getPanel();
@@ -60,6 +67,7 @@ public class AnthropicSettingsForm {
     var state = new AnthropicSettingsState();
     state.setModel(modelField.getText());
     state.setApiVersion(apiVersionField.getText());
+    state.setHost(hostField.getText());
     return state;
   }
 
@@ -68,6 +76,7 @@ public class AnthropicSettingsForm {
     apiKeyField.setText(CredentialsStore.getCredential(ANTHROPIC_API_KEY));
     apiVersionField.setText(state.getApiVersion());
     modelField.setText(state.getModel());
+    hostField.setText(state.getHost());
   }
 
   public @Nullable String getApiKey() {

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettingsState.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettingsState.java
@@ -6,6 +6,7 @@ public class AnthropicSettingsState {
 
   private String apiVersion = "2023-06-01";
   private String model = "claude-3-opus-20240229";
+  private String host = "";
 
   public String getApiVersion() {
     return apiVersion;
@@ -23,6 +24,14 @@ public class AnthropicSettingsState {
     this.model = model;
   }
 
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(final String host) {
+    this.host = host;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -32,11 +41,11 @@ public class AnthropicSettingsState {
       return false;
     }
     AnthropicSettingsState that = (AnthropicSettingsState) o;
-    return Objects.equals(apiVersion, that.apiVersion) && Objects.equals(model, that.model);
+    return Objects.equals(apiVersion, that.apiVersion) && Objects.equals(model, that.model) && Objects.equals(host, that.host);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(apiVersion, model);
+    return Objects.hash(apiVersion, model, host);
   }
 }

--- a/src/main/resources/messages/codegpt.properties
+++ b/src/main/resources/messages/codegpt.properties
@@ -50,9 +50,11 @@ settingsConfigurable.service.openai.organization.label=Organization:
 settingsConfigurable.section.openai.organization.comment=Useful when you are part of multiple organizations <sup><strong>optional</strong></sup>
 settingsConfigurable.service.google.apiKey.comment=You can find the API key in your <a href="https://aistudio.google.com/app/apikey">User settings</a>.
 settingsConfigurable.service.google.model.comment=Note: Gemini Vision models <a href="https://ai.google.dev/gemini-api/docs/get-started/web?multi-turn-conversations-chat&hl=en#multi-turn-conversations-chat">do not yet support chats</a>.
+settingsConfigurable.service.custom.anthropic.url.label=URL:
 settingsConfigurable.service.anthropic.apiKey.comment=You can find the API key in your <a href="https://console.anthropic.com/settings/keys">User settings</a>.
 settingsConfigurable.service.anthropic.apiVersion.comment=We always recommend using the <a href="https://docs.anthropic.com/claude/reference/versions">latest API version</a> whenever possible.
 settingsConfigurable.service.anthropic.model.comment=For details on model comparison metrics, see <a href="https://docs.anthropic.com/claude/docs/models-overview#model-comparison">model comparison</a>.
+settingsConfigurable.service.anthropic.url.comment=Optional, defaults to https://api.anthropic.com.
 settingsConfigurable.service.azure.resourceName.label=Resource name:
 settingsConfigurable.service.azure.resourceName.comment=The name of your Azure OpenAI resource.
 settingsConfigurable.service.azure.deploymentId.label=Deployment ID:


### PR DESCRIPTION
I am using Anthropic's API over AWS bedrock, and to access a anthropic api -> bedrock proxy, I  had to add the ability to change the API url. A nicer way would be to  add another sub-setting like Custom OpenAI, but I didn't have enough time to do so. This PR simply adds another optional field `Host` to the Anthropic settings, which may be left empty. Feel free to dismiss this PR without any explanation.

Great extension, by the way! Kudos!