### PR TITLE
Fix suggestions popup positioning and tag panel styling

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/header/tag/TagPanel.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/header/tag/TagPanel.kt
@@ -9,7 +9,12 @@ import com.intellij.util.IconUtil
 import com.intellij.util.ui.JBUI
 import ee.carlrobert.codegpt.ui.textarea.PromptTextField
 import ee.carlrobert.codegpt.ui.textarea.header.PaintUtil
-import java.awt.*
+import java.awt.Cursor
+import java.awt.Dimension
+import java.awt.Graphics
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import javax.swing.BorderFactory
 import javax.swing.Icon
 import javax.swing.JButton
 import javax.swing.JToggleButton
@@ -46,7 +51,7 @@ abstract class TagPanel(
         val closeButtonWidth = if (closeButton.isVisible) closeButton.preferredSize.width else 0
         return Dimension(
             label.preferredSize.width + closeButtonWidth + insets.left + insets.right,
-            20
+            JBUI.scale(20)
         )
     }
 
@@ -134,8 +139,13 @@ abstract class TagPanel(
                 onClose()
             }
 
-            preferredSize = Dimension(Close.iconWidth, Close.iconHeight)
-            border = JBUI.Borders.emptyLeft(4)
+            val iconSize = Dimension(Close.iconWidth, Close.iconHeight)
+            preferredSize = iconSize
+            minimumSize = iconSize
+            maximumSize = iconSize
+
+            border = BorderFactory.createEmptyBorder(0, 4, 0, 4)
+
             isContentAreaFilled = false
             toolTipText = "Remove"
             rolloverIcon = AllIcons.Actions.CloseHovered


### PR DESCRIPTION
Fixed the display of tags when the font size is 15 and higher. I changed the pop-up display on macOS, when using multiple screens, the pop-up was shown on the main screen, although the IDE was on another one.

<img width="538" alt="Снимок экрана 2025-03-21 в 18 49 47" src="https://github.com/user-attachments/assets/eea17859-06d7-4e61-b1bf-5f530d787e0a" /> 

↓

<img width="243" alt="Снимок экрана 2025-03-21 в 18 50 06" src="https://github.com/user-attachments/assets/1e0b8e24-3890-40e5-a1fe-2ecbd0f02fc8" />

