### PR TITLE
feat: custom base host support for anthropic privider

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionClientProvider.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionClientProvider.java
@@ -3,6 +3,7 @@ package ee.carlrobert.codegpt.completions;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.getCredential;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.util.net.ssl.CertificateManager;
 import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey;
 import ee.carlrobert.codegpt.settings.advanced.AdvancedSettings;
 import ee.carlrobert.codegpt.settings.service.anthropic.AnthropicSettings;
@@ -21,6 +22,7 @@ import ee.carlrobert.llm.client.openai.OpenAIClient;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.X509TrustManager;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 
@@ -98,6 +100,9 @@ public class CompletionClientProvider {
 
   public static OkHttpClient.Builder getDefaultClientBuilder() {
     OkHttpClient.Builder builder = new OkHttpClient.Builder();
+    CertificateManager certificateManager = CertificateManager.getInstance();
+    X509TrustManager trustManager = certificateManager.getTrustManager();
+    builder.sslSocketFactory(certificateManager.getSslContext().getSocketFactory(), trustManager);
     var advancedSettings = AdvancedSettings.getCurrentState();
     var proxyHost = advancedSettings.getProxyHost();
     var proxyPort = advancedSettings.getProxyPort();

--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionClientProvider.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionClientProvider.java
@@ -39,10 +39,12 @@ public class CompletionClientProvider {
   }
 
   public static ClaudeClient getClaudeClient() {
-    return new ClaudeClient(
-        getCredential(CredentialKey.AnthropicApiKey.INSTANCE),
-        AnthropicSettings.getCurrentState().getApiVersion(),
-        getDefaultClientBuilder());
+    var builder = new ClaudeClient.Builder(getCredential(CredentialKey.AnthropicApiKey.INSTANCE),
+            AnthropicSettings.getCurrentState().getApiVersion());
+    if (AnthropicSettings.getCurrentState().hasCustomBaseHost()) {
+      builder.setHost(AnthropicSettings.getCurrentState().getBaseHost());
+    }
+    return builder.build(getDefaultClientBuilder());
   }
 
   public static AzureClient getAzureClient() {

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettingsForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettingsForm.java
@@ -17,6 +17,7 @@ public class AnthropicSettingsForm {
   private final JBPasswordField apiKeyField;
   private final JBTextField apiVersionField;
   private final JBTextField modelField;
+  private final JBTextField baseHostField;
 
   public AnthropicSettingsForm(AnthropicSettingsState settings) {
     apiKeyField = new JBPasswordField();
@@ -29,6 +30,7 @@ public class AnthropicSettingsForm {
     });
     apiVersionField = new JBTextField(settings.getApiVersion(), 35);
     modelField = new JBTextField(settings.getModel(), 35);
+    baseHostField = new JBTextField(settings.getBaseHost(), 35);
   }
 
   public JPanel getForm() {
@@ -51,6 +53,10 @@ public class AnthropicSettingsForm {
                 .withComment(CodeGPTBundle.get(
                     "settingsConfigurable.service.anthropic.model.comment"))
                 .resizeX(false))
+            .add(UI.PanelFactory.panel(baseHostField)
+                .withLabel(CodeGPTBundle.get("settingsConfigurable.shared.baseHost.label"))
+                .withComment("Optional: Custom API endpoint (e.g., https://api.anthropic.com)")
+                .resizeX(false))
             .createPanel())
         .addComponentFillVertically(new JPanel(), 0)
         .getPanel();
@@ -60,6 +66,7 @@ public class AnthropicSettingsForm {
     var state = new AnthropicSettingsState();
     state.setModel(modelField.getText());
     state.setApiVersion(apiVersionField.getText());
+    state.setBaseHost(baseHostField.getText());
     return state;
   }
 
@@ -70,6 +77,7 @@ public class AnthropicSettingsForm {
     );
     apiVersionField.setText(state.getApiVersion());
     modelField.setText(state.getModel());
+    baseHostField.setText(state.getBaseHost());
   }
 
   public @Nullable String getApiKey() {

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettingsState.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettingsState.java
@@ -6,6 +6,7 @@ public class AnthropicSettingsState {
 
   private String apiVersion = "2023-06-01";
   private String model = "claude-3-opus-20240229";
+  private String baseHost = "";
 
   public String getApiVersion() {
     return apiVersion;
@@ -23,6 +24,18 @@ public class AnthropicSettingsState {
     this.model = model;
   }
 
+  public String getBaseHost() {
+    return baseHost;
+  }
+
+  public void setBaseHost(String baseHost) {
+    this.baseHost = baseHost;
+  }
+
+  public boolean hasCustomBaseHost() {
+    return baseHost != null && !baseHost.trim().isEmpty();
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -32,11 +45,13 @@ public class AnthropicSettingsState {
       return false;
     }
     AnthropicSettingsState that = (AnthropicSettingsState) o;
-    return Objects.equals(apiVersion, that.apiVersion) && Objects.equals(model, that.model);
+    return Objects.equals(apiVersion, that.apiVersion)
+            && Objects.equals(model, that.model)
+            && Objects.equals(baseHost, that.baseHost);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(apiVersion, model);
+    return Objects.hash(apiVersion, model, baseHost);
   }
 }


### PR DESCRIPTION
### Why
Certain organizations use their own proxies for AI tools. Multiple tools, including Cline, offer support for custom hosts/URLs to accommodate these proxies.

### What
- add custom host setting
- use jetbrains-provided tls bundle

The default okhttp3 bundle does not include additional certificates that might be installed on your system, so utilizing the JetBrains-provided TLS bundle ensures all necessary certificates are considered.

<img width="800" alt="Screenshot 2025-03-26 at 19 22 58" src="https://github.com/user-attachments/assets/da6a902a-5bec-426e-99c2-1d22d4d0a479" />
