### PR TITLE
new icon to indicate that LLaMA model is not downloaded

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/completions/llama/LlamaModel.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/llama/LlamaModel.java
@@ -302,7 +302,7 @@ public enum LlamaModel {
   }
 
   public static String getDownloadedMarker(boolean downloaded) {
-    return downloaded ? "✓" : "\u2001";
+    return downloaded ? "✓" : "⤓";
   }
 
   public static @NotNull Path getLlamaModelsPath() {


### PR DESCRIPTION
When I first opened this tab, I didn't understand why the left indent was needed. Only then I realized that this is a description of the state of the model downloaded or not. 
As to me it is very confusing. After adding an icon, you can realize that the model still needs to be downloaded.

<img width="1323" src="https://github.com/user-attachments/assets/71a7a14c-13ea-4255-a76a-6fc19707a74d" />
