### PR TITLE
Add separate model selection for code completion

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettings.java
@@ -8,6 +8,7 @@ import ee.carlrobert.codegpt.CodeGPTKeys;
 import ee.carlrobert.codegpt.completions.HuggingFaceModel;
 import ee.carlrobert.codegpt.completions.llama.LlamaModel;
 import ee.carlrobert.codegpt.conversations.Conversation;
+import ee.carlrobert.codegpt.settings.service.ModelRole;
 import ee.carlrobert.codegpt.settings.service.ProviderChangeNotifier;
 import ee.carlrobert.codegpt.settings.service.ServiceType;
 import ee.carlrobert.codegpt.settings.service.anthropic.AnthropicSettings;
@@ -20,6 +21,8 @@ import ee.carlrobert.codegpt.settings.service.ollama.OllamaSettings;
 import ee.carlrobert.codegpt.settings.service.openai.OpenAISettings;
 import ee.carlrobert.codegpt.util.ApplicationUtil;
 import org.jetbrains.annotations.NotNull;
+
+import static ee.carlrobert.codegpt.settings.service.ModelRole.CHAT_ROLE;
 
 @State(name = "CodeGPT_GeneralSettings_270", storages = @Storage("CodeGPT_GeneralSettings_270.xml"))
 public class GeneralSettings implements PersistentStateComponent<GeneralSettingsState> {
@@ -46,11 +49,19 @@ public class GeneralSettings implements PersistentStateComponent<GeneralSettings
   }
 
   public static ServiceType getSelectedService() {
-    return getCurrentState().getSelectedService();
+    return getCurrentState().getSelectedService(CHAT_ROLE);
+  }
+
+  public static ServiceType getSelectedService(ModelRole role) {
+    return getCurrentState().getSelectedService(role);
   }
 
   public static boolean isSelected(ServiceType serviceType) {
     return getSelectedService() == serviceType;
+  }
+
+  public static boolean isSelected(ModelRole role, ServiceType serviceType) {
+    return getSelectedService(role) == serviceType;
   }
 
   public void sync(Conversation conversation) {
@@ -95,7 +106,7 @@ public class GeneralSettings implements PersistentStateComponent<GeneralSettings
       default:
         break;
     }
-    state.setSelectedService(provider);
+    state.setSelectedService(CHAT_ROLE, provider);
     if (project != null) {
       project.getMessageBus()
           .syncPublisher(ProviderChangeNotifier.getTOPIC())

--- a/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettingsState.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettingsState.java
@@ -1,14 +1,18 @@
 package ee.carlrobert.codegpt.settings;
 
 import com.intellij.openapi.application.ApplicationManager;
+import ee.carlrobert.codegpt.settings.service.ModelRole;
 import ee.carlrobert.codegpt.settings.service.ProviderChangeNotifier;
 import ee.carlrobert.codegpt.settings.service.ServiceType;
+
+import static ee.carlrobert.codegpt.settings.service.ModelRole.*;
 
 public class GeneralSettingsState {
 
   private String displayName = "";
   private String avatarBase64 = "";
   private ServiceType selectedService = ServiceType.CODEGPT;
+  private ServiceType codeCompletionService = ServiceType.CODEGPT;
 
   public String getDisplayName() {
     if (displayName == null || displayName.isEmpty()) {
@@ -33,16 +37,35 @@ public class GeneralSettingsState {
     this.avatarBase64 = avatarBase64;
   }
 
+  public ServiceType getSelectedService(ModelRole role) {
+    switch (role) {
+      case CHAT_ROLE -> {return selectedService;}
+      case CODECOMPLETION_ROLE -> {return codeCompletionService;}
+      default -> {throw new AssertionError();}
+    }
+  }
   public ServiceType getSelectedService() {
-    return selectedService;
+    return getSelectedService(CHAT_ROLE);
+  }
+
+  public void setSelectedService(ModelRole role, ServiceType selectedService) {
+    switch (role) {
+      case CHAT_ROLE -> {
+        this.selectedService = selectedService;
+
+        ApplicationManager.getApplication()
+                .getMessageBus()
+                .syncPublisher(ProviderChangeNotifier.getTOPIC())
+                .providerChanged(selectedService);
+      }
+      case CODECOMPLETION_ROLE -> {
+        this.codeCompletionService = selectedService;
+      }
+      default -> {throw new AssertionError();}
+    }
   }
 
   public void setSelectedService(ServiceType selectedService) {
-    this.selectedService = selectedService;
-
-    ApplicationManager.getApplication()
-        .getMessageBus()
-        .syncPublisher(ProviderChangeNotifier.getTOPIC())
-        .providerChanged(selectedService);
+    setSelectedService(CHAT_ROLE, selectedService);
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/ModelRole.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/ModelRole.java
@@ -1,0 +1,6 @@
+package ee.carlrobert.codegpt.settings.service;
+
+public enum ModelRole {
+    CHAT_ROLE,
+    CODECOMPLETION_ROLE
+};

--- a/src/main/kotlin/ee/carlrobert/codegpt/actions/CodeCompletionFeatureToggleActions.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/actions/CodeCompletionFeatureToggleActions.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbAwareAction
 import ee.carlrobert.codegpt.codecompletions.CodeCompletionService
 import ee.carlrobert.codegpt.settings.GeneralSettings
+import ee.carlrobert.codegpt.settings.service.ModelRole.CODECOMPLETION_ROLE
 import ee.carlrobert.codegpt.settings.service.ServiceType.*
 import ee.carlrobert.codegpt.settings.service.codegpt.CodeGPTServiceSettings
 import ee.carlrobert.codegpt.settings.service.custom.CustomServicesSettings
@@ -17,7 +18,7 @@ abstract class CodeCompletionFeatureToggleActions(
     private val enableFeatureAction: Boolean
 ) : DumbAwareAction() {
 
-    override fun actionPerformed(e: AnActionEvent) = when (GeneralSettings.getSelectedService()) {
+    override fun actionPerformed(e: AnActionEvent) = when (GeneralSettings.getSelectedService(CODECOMPLETION_ROLE)) {
         CODEGPT -> service<CodeGPTServiceSettings>().state.codeCompletionSettings::codeCompletionsEnabled::set
 
         OPENAI -> OpenAISettings.getCurrentState()::setCodeCompletionsEnabled
@@ -35,7 +36,7 @@ abstract class CodeCompletionFeatureToggleActions(
     }(enableFeatureAction)
 
     override fun update(e: AnActionEvent) {
-        val selectedService = GeneralSettings.getSelectedService()
+        val selectedService = GeneralSettings.getSelectedService(CODECOMPLETION_ROLE)
         val codeCompletionEnabled =
             e.project?.service<CodeCompletionService>()?.isCodeCompletionsEnabled(selectedService)
                 ?: false

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionEventListener.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionEventListener.kt
@@ -13,6 +13,7 @@ import ee.carlrobert.codegpt.CodeGPTKeys
 import ee.carlrobert.codegpt.codecompletions.edit.GrpcClientService
 import ee.carlrobert.codegpt.settings.GeneralSettings
 import ee.carlrobert.codegpt.settings.configuration.ConfigurationSettings
+import ee.carlrobert.codegpt.settings.service.ModelRole.CODECOMPLETION_ROLE
 import ee.carlrobert.codegpt.settings.service.ServiceType
 import ee.carlrobert.codegpt.settings.service.codegpt.CodeGPTServiceSettings
 import ee.carlrobert.codegpt.treesitter.CodeCompletionParserFactory
@@ -156,7 +157,7 @@ class CodeCompletionEventListener(
     }
 
     override fun onError(error: ErrorDetails, ex: Throwable) {
-        val isCodeGPTService = GeneralSettings.getSelectedService() == ServiceType.CODEGPT
+        val isCodeGPTService = GeneralSettings.getSelectedService(CODECOMPLETION_ROLE) == ServiceType.CODEGPT
         if (isCodeGPTService && "RATE_LIMIT_EXCEEDED" == error.code) {
             service<CodeGPTServiceSettings>().state
                 .codeCompletionSettings

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionRequestFactory.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionRequestFactory.kt
@@ -127,7 +127,7 @@ object CodeCompletionRequestFactory {
         }
 
         return OllamaCompletionRequest.Builder(
-            settings.model,
+            settings.codeCompletionModel,
             prompt
         )
             .setSuffix(if (settings.fimOverride) null else details.suffix)

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionService.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionService.kt
@@ -41,7 +41,7 @@ class CodeCompletionService(private val project: Project) {
                 .getOrDefault("model", null) as String
 
             LLAMA_CPP -> LlamaModel.findByHuggingFaceModel(LlamaSettings.getCurrentState().huggingFaceModel).label
-            OLLAMA -> service<OllamaSettings>().state.model
+            OLLAMA -> service<OllamaSettings>().state.codeCompletionModel
             else -> null
         }
     }

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionService.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionService.kt
@@ -12,6 +12,7 @@ import ee.carlrobert.codegpt.codecompletions.edit.GrpcClientService
 import ee.carlrobert.codegpt.completions.CompletionClientProvider
 import ee.carlrobert.codegpt.completions.llama.LlamaModel
 import ee.carlrobert.codegpt.settings.GeneralSettings
+import ee.carlrobert.codegpt.settings.service.ModelRole.CODECOMPLETION_ROLE
 import ee.carlrobert.codegpt.settings.service.ServiceType
 import ee.carlrobert.codegpt.settings.service.ServiceType.*
 import ee.carlrobert.codegpt.settings.service.codegpt.CodeGPTServiceSettings
@@ -46,7 +47,7 @@ class CodeCompletionService(private val project: Project) {
         }
     }
 
-    fun isCodeCompletionsEnabled(): Boolean = isCodeCompletionsEnabled(GeneralSettings.getSelectedService())
+    fun isCodeCompletionsEnabled(): Boolean = isCodeCompletionsEnabled(GeneralSettings.getSelectedService(CODECOMPLETION_ROLE))
 
     fun isCodeCompletionsEnabled(selectedService: ServiceType): Boolean =
         when (selectedService) {
@@ -62,7 +63,7 @@ class CodeCompletionService(private val project: Project) {
         infillRequest: InfillRequest,
         eventListener: CompletionEventListener<String>
     ): EventSource {
-        return when (val selectedService = GeneralSettings.getSelectedService()) {
+        return when (val selectedService = GeneralSettings.getSelectedService(CODECOMPLETION_ROLE)) {
             OPENAI -> CompletionClientProvider.getOpenAIClient()
                 .getCompletionAsync(buildOpenAIRequest(infillRequest), eventListener)
 

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/DebouncedCodeCompletionProvider.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/DebouncedCodeCompletionProvider.kt
@@ -10,6 +10,7 @@ import com.intellij.platform.workspace.storage.impl.cache.cache
 import ee.carlrobert.codegpt.CodeGPTKeys.REMAINING_CODE_COMPLETION
 import ee.carlrobert.codegpt.codecompletions.edit.GrpcClientService
 import ee.carlrobert.codegpt.settings.GeneralSettings
+import ee.carlrobert.codegpt.settings.service.ModelRole.*
 import ee.carlrobert.codegpt.settings.service.ServiceType
 import ee.carlrobert.codegpt.settings.service.codegpt.CodeGPTServiceSettings
 import ee.carlrobert.codegpt.settings.service.custom.CustomServicesSettings
@@ -74,7 +75,7 @@ class DebouncedCodeCompletionProvider : DebouncedInlineCompletionProvider() {
 
                 var eventListener = CodeCompletionEventListener(request.editor, this)
 
-                if (GeneralSettings.getSelectedService() == ServiceType.CODEGPT) {
+                if (GeneralSettings.getSelectedService(CODECOMPLETION_ROLE) == ServiceType.CODEGPT) {
                     project.service<GrpcClientService>().getCodeCompletionAsync(eventListener, request, this)
                     return@channelFlow
                 }
@@ -103,7 +104,7 @@ class DebouncedCodeCompletionProvider : DebouncedInlineCompletionProvider() {
     }
 
     override fun isEnabled(event: InlineCompletionEvent): Boolean {
-        val selectedService = GeneralSettings.getSelectedService()
+        val selectedService = GeneralSettings.getSelectedService(CODECOMPLETION_ROLE)
         val codeCompletionsEnabled = when (selectedService) {
             ServiceType.CODEGPT -> service<CodeGPTServiceSettings>().state.codeCompletionSettings.codeCompletionsEnabled
             ServiceType.OPENAI -> OpenAISettings.getCurrentState().isCodeCompletionsEnabled

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ServiceConfigurable.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ServiceConfigurable.kt
@@ -1,5 +1,6 @@
 package ee.carlrobert.codegpt.settings.service
 
+import ee.carlrobert.codegpt.settings.service.ModelRole.*
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.Configurable
 import ee.carlrobert.codegpt.conversations.ConversationsState
@@ -23,24 +24,28 @@ class ServiceConfigurable : Configurable {
     }
 
     override fun isModified(): Boolean {
-        return component.getSelectedService() != service<GeneralSettings>().state.selectedService
+        return component.getSelectedService(CHAT_ROLE) != service<GeneralSettings>().state.getSelectedService(CHAT_ROLE)
+                || component.getSelectedService(CODECOMPLETION_ROLE) != service<GeneralSettings>().state.getSelectedService(CODECOMPLETION_ROLE)
     }
 
     override fun apply() {
         val state = service<GeneralSettings>().state
-        state.selectedService = component.getSelectedService()
+        state.setSelectedService(CHAT_ROLE, component.getSelectedService(CHAT_ROLE))
 
-        val serviceChanged = component.getSelectedService() != state.selectedService
+        val serviceChanged = component.getSelectedService(CHAT_ROLE) != state.selectedService
         if (serviceChanged) {
             resetActiveTab()
             TelemetryAction.SETTINGS_CHANGED.createActionMessage()
-                .property("service", component.getSelectedService().code.lowercase())
+                .property("service", component.getSelectedService(CHAT_ROLE).code.lowercase())
                 .send()
         }
+
+        state.setSelectedService(CODECOMPLETION_ROLE, component.getSelectedService(CODECOMPLETION_ROLE))
     }
 
     override fun reset() {
-        component.setSelectedService(service<GeneralSettings>().state.selectedService)
+        component.setSelectedService(CHAT_ROLE,service<GeneralSettings>().state.getSelectedService(CHAT_ROLE))
+        component.setSelectedService(CODECOMPLETION_ROLE,service<GeneralSettings>().state.getSelectedService(CODECOMPLETION_ROLE))
     }
 
     private fun resetActiveTab() {

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ServiceConfigurableComponent.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ServiceConfigurableComponent.kt
@@ -1,5 +1,6 @@
 package ee.carlrobert.codegpt.settings.service
 
+import ee.carlrobert.codegpt.settings.service.ModelRole.*
 import com.intellij.ide.DataManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.ex.Settings
@@ -23,21 +24,35 @@ class ServiceConfigurableComponent {
 
     private var serviceComboBox: ComboBox<ServiceType> =
         ComboBox(EnumComboBoxModel(ServiceType::class.java)).apply {
-            selectedItem = service<GeneralSettings>().state.selectedService
+            selectedItem = service<GeneralSettings>().state.getSelectedService(CHAT_ROLE)
+        }
+    private var codeCompletionServiceComboBox: ComboBox<ServiceType> =
+        ComboBox(EnumComboBoxModel(ServiceType::class.java)).apply {
+            selectedItem = service<GeneralSettings>().state.getSelectedService(CODECOMPLETION_ROLE)
         }
 
-    fun getSelectedService(): ServiceType {
-        return serviceComboBox.selectedItem as ServiceType
+    fun getSelectedService(role: ModelRole): ServiceType {
+        return when(role) {
+            CHAT_ROLE -> serviceComboBox
+            CODECOMPLETION_ROLE -> codeCompletionServiceComboBox
+        }.selectedItem as ServiceType
     }
 
-    fun setSelectedService(serviceType: ServiceType) {
-        serviceComboBox.selectedItem = serviceType
+    fun setSelectedService(role: ModelRole, serviceType: ServiceType) {
+        when(role) {
+            CHAT_ROLE -> serviceComboBox
+            CODECOMPLETION_ROLE -> codeCompletionServiceComboBox
+        }.selectedItem = serviceType
     }
 
     fun getPanel(): JPanel = FormBuilder.createFormBuilder()
         .addLabeledComponent(
             CodeGPTBundle.get("settingsConfigurable.service.label"),
             serviceComboBox
+        )
+        .addLabeledComponent(
+            CodeGPTBundle.get("settingsConfigurable.service.codeCompletion.label"),
+            codeCompletionServiceComboBox
         )
         .addVerticalGap(8)
         .addComponent(JBLabel("All available providers that can be used with CodeGPT:"))

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ollama/OllamaSettings.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ollama/OllamaSettings.kt
@@ -13,6 +13,7 @@ class OllamaSettings :
 class OllamaSettingsState : BaseState() {
     var host by string("http://localhost:11434")
     var model by string()
+    var codeCompletionModel by string()
     var codeCompletionsEnabled by property(false)
     var fimOverride by property(true)
     var fimTemplate by enum<InfillPromptTemplate>(InfillPromptTemplate.CODE_QWEN_2_5)

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ollama/OllamaSettingsForm.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ollama/OllamaSettingsForm.kt
@@ -25,7 +25,7 @@ import ee.carlrobert.codegpt.ui.URLTextField
 import ee.carlrobert.llm.client.ollama.OllamaClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import java.awt.BorderLayout
+import java.awt.Dimension
 import java.lang.String.format
 import java.net.ConnectException
 import java.util.concurrent.TimeoutException
@@ -36,10 +36,16 @@ import javax.swing.JPanel
 
 class OllamaSettingsForm {
 
+    enum class ModelRole {
+        CHAT_ROLE, CODECOMPLETION_ROLE
+    }
+    private val CHAT_ROLE = ModelRole.CHAT_ROLE
+    private val CODECOMPLETION_ROLE = ModelRole.CODECOMPLETION_ROLE
+
     private val refreshModelsButton =
         JButton(CodeGPTBundle.get("settingsConfigurable.service.ollama.models.refresh"))
     private val hostField: JBTextField
-    private val modelComboBox: ComboBox<String>
+    private val modelComboBoxes: Map<ModelRole, ComboBox<String>>
     private val codeCompletionConfigurationForm: CodeCompletionConfigurationForm
     private val apiKeyField: JBPasswordField
 
@@ -56,18 +62,24 @@ class OllamaSettingsForm {
         )
         val emptyModelsComboBoxModel =
             DefaultComboBoxModel(arrayOf("Hit refresh to see models for this host"))
-        modelComboBox = ComboBox(emptyModelsComboBoxModel).apply {
+        modelComboBoxes = ModelRole.entries.associate { it to ComboBox(emptyModelsComboBoxModel).apply {
             isEnabled = false
-        }
-        hostField = URLTextField().apply {
+            preferredSize = Dimension(280, preferredSize.height)
+        } }
+        hostField = URLTextField(30).apply {
             text = settings.host
             whenTextChangedFromUi {
-                modelComboBox.model = emptyModelsComboBoxModel
-                modelComboBox.isEnabled = false
+                modelComboBoxes.values.forEach { comboBox ->
+                    comboBox.model = emptyModelsComboBoxModel
+                    comboBox.isEnabled = false
+                }
             }
         }
         refreshModelsButton.addActionListener {
-            refreshModels(getModel() ?: settings.model)
+            refreshModels(mapOf(
+                CHAT_ROLE to (getModel(CHAT_ROLE) ?: settings.model),
+                CODECOMPLETION_ROLE to (getModel(CODECOMPLETION_ROLE) ?: settings.codeCompletionModel),
+                ))
         }
         apiKeyField = JBPasswordField().apply {
             columns = 30
@@ -88,11 +100,13 @@ class OllamaSettingsForm {
                 )
                 .addLabeledComponent(
                     CodeGPTBundle.get("settingsConfigurable.shared.model.label"),
-                    JPanel(BorderLayout(8, 0)).apply {
-                        add(modelComboBox, BorderLayout.CENTER)
-                        add(refreshModelsButton, BorderLayout.EAST)
-                    }
+                    modelComboBoxes[CHAT_ROLE]!!
                 )
+                .addLabeledComponent(
+                    CodeGPTBundle.get("settingsConfigurable.service.ollama.codeCompletionModel.label"),
+                    modelComboBoxes[CODECOMPLETION_ROLE]!!
+                )
+                .addComponent(refreshModelsButton)
                 .addComponent(TitledSeparator(CodeGPTBundle.get("settingsConfigurable.shared.authentication.title")))
                 .setFormLeftIndent(32)
                 .addLabeledComponent(
@@ -107,9 +121,9 @@ class OllamaSettingsForm {
         .addComponentFillVertically(JPanel(), 0)
         .panel
 
-    fun getModel(): String? {
-        return if (modelComboBox.isEnabled) {
-            modelComboBox.item
+    fun getModel(role: ModelRole): String? {
+        return if (modelComboBoxes[role]!!.isEnabled) {
+            modelComboBoxes[role]!!.item
         } else {
             null
         }
@@ -120,7 +134,8 @@ class OllamaSettingsForm {
     fun resetForm() {
         service<OllamaSettings>().state.run {
             hostField.text = host
-            modelComboBox.item = model ?: ""
+            modelComboBoxes[CHAT_ROLE]!!.item = model ?: ""
+            modelComboBoxes[CODECOMPLETION_ROLE]!!.item = codeCompletionModel ?: ""
             codeCompletionConfigurationForm.isCodeCompletionsEnabled = codeCompletionsEnabled
             codeCompletionConfigurationForm.fimTemplate = fimTemplate
             codeCompletionConfigurationForm.fimOverride != fimOverride
@@ -131,7 +146,10 @@ class OllamaSettingsForm {
     fun applyChanges() {
         service<OllamaSettings>().state.run {
             host = hostField.text
-            model = modelComboBox.item
+            if (modelComboBoxes[CHAT_ROLE]!!.isEnabled)
+                model = modelComboBoxes[CHAT_ROLE]!!.item
+            if (modelComboBoxes[CODECOMPLETION_ROLE]!!.isEnabled)
+                codeCompletionModel = modelComboBoxes[CODECOMPLETION_ROLE]!!.item
             codeCompletionsEnabled = codeCompletionConfigurationForm.isCodeCompletionsEnabled
             fimTemplate = codeCompletionConfigurationForm.fimTemplate!!
             fimOverride = codeCompletionConfigurationForm.fimOverride ?: false
@@ -141,14 +159,15 @@ class OllamaSettingsForm {
 
     fun isModified() = service<OllamaSettings>().state.run {
         hostField.text != host
-                || (modelComboBox.item != model && modelComboBox.isEnabled)
+                || (modelComboBoxes[CHAT_ROLE]!!.item != model && modelComboBoxes[CHAT_ROLE]!!.isEnabled)
+                || (modelComboBoxes[CODECOMPLETION_ROLE]!!.item != codeCompletionModel && modelComboBoxes[CODECOMPLETION_ROLE]!!.isEnabled)
                 || codeCompletionConfigurationForm.isCodeCompletionsEnabled != codeCompletionsEnabled
                 || codeCompletionConfigurationForm.fimTemplate != fimTemplate
                 || codeCompletionConfigurationForm.fimOverride != fimOverride
                 || getApiKey() != getCredential(OllamaApikey)
     }
 
-    private fun refreshModels(currentModel: String?) {
+    private fun refreshModels(currentModels: Map<ModelRole, String?>) {
         disableModelComboBoxWithPlaceholder(DefaultComboBoxModel(arrayOf("Loading")))
         ReadAction.nonBlocking<List<String>> {
             try {
@@ -168,31 +187,33 @@ class OllamaSettingsForm {
             }
         }
             .finishOnUiThread(ModalityState.defaultModalityState()) { models ->
-                updateModelComboBoxState(models, currentModel)
+                updateModelComboBoxState(models, currentModels)
             }
             .submit(AppExecutorUtil.getAppExecutorService())
     }
 
-    private fun updateModelComboBoxState(models: List<String>, currentModel: String?) {
+    private fun updateModelComboBoxState(models: List<String>, currentModels: Map<ModelRole, String?>) {
         if (models.isNotEmpty()) {
-            modelComboBox.model = DefaultComboBoxModel(models.toTypedArray())
-            modelComboBox.isEnabled = true
-            currentModel?.let {
-                if (models.contains(currentModel)) {
-                    modelComboBox.selectedItem = currentModel
-                } else {
-                    OverlayUtil.showBalloon(
-                        format(
-                            CodeGPTBundle.get("validation.error.model.notExists"),
-                            currentModel
-                        ),
-                        MessageType.ERROR,
-                        modelComboBox
-                    )
+            modelComboBoxes.forEach { (role, comboBox) ->
+                comboBox.model = DefaultComboBoxModel(models.toTypedArray())
+                comboBox.isEnabled = true
+                currentModels[role]?.let {
+                    if (models.contains(currentModels[role])) {
+                        comboBox.selectedItem = currentModels[role]
+                    } else {
+                        OverlayUtil.showBalloon(
+                            format(
+                                CodeGPTBundle.get("validation.error.model.notExists"),
+                                currentModels[role]
+                            ),
+                            MessageType.ERROR,
+                            comboBox
+                        )
+                    }
                 }
             }
         } else {
-            modelComboBox.model = DefaultComboBoxModel(arrayOf("No models"))
+            disableModelComboBoxWithPlaceholder(DefaultComboBoxModel(arrayOf("No models")))
         }
         val availableModels = ApplicationManager.getApplication()
             .getService(OllamaSettings::class.java)
@@ -229,9 +250,11 @@ class OllamaSettingsForm {
     }
 
     private fun disableModelComboBoxWithPlaceholder(placeholderModel: ComboBoxModel<String>) {
-        modelComboBox.apply {
-            model = placeholderModel
-            isEnabled = false
+        modelComboBoxes.values.forEach { comboBox ->
+            comboBox.apply {
+                model = placeholderModel
+                isEnabled = false
+            }
         }
     }
 }

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ollama/OllamaSettingsForm.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ollama/OllamaSettingsForm.kt
@@ -19,6 +19,8 @@ import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.OllamaAp
 import ee.carlrobert.codegpt.credentials.CredentialsStore.getCredential
 import ee.carlrobert.codegpt.credentials.CredentialsStore.setCredential
 import ee.carlrobert.codegpt.settings.service.CodeCompletionConfigurationForm
+import ee.carlrobert.codegpt.settings.service.ModelRole
+import ee.carlrobert.codegpt.settings.service.ModelRole.*
 import ee.carlrobert.codegpt.ui.OverlayUtil
 import ee.carlrobert.codegpt.ui.UIUtil
 import ee.carlrobert.codegpt.ui.URLTextField
@@ -35,12 +37,6 @@ import javax.swing.JButton
 import javax.swing.JPanel
 
 class OllamaSettingsForm {
-
-    enum class ModelRole {
-        CHAT_ROLE, CODECOMPLETION_ROLE
-    }
-    private val CHAT_ROLE = ModelRole.CHAT_ROLE
-    private val CODECOMPLETION_ROLE = ModelRole.CODECOMPLETION_ROLE
 
     private val refreshModelsButton =
         JButton(CodeGPTBundle.get("settingsConfigurable.service.ollama.models.refresh"))

--- a/src/main/resources/messages/codegpt.properties
+++ b/src/main/resources/messages/codegpt.properties
@@ -179,6 +179,7 @@ settingsConfigurable.prompts.exportDialog.exportError=Error exporting prompts se
 settingsConfigurable.prompts.exportDialog.title=Target File
 settingsConfigurable.prompts.importDialog.importError=Error importing prompts settings
 settingsConfigurable.service.ollama.models.refresh=Refresh Models
+settingsConfigurable.service.ollama.codeCompletionModel.label=Model for code completion:
 advancedSettingsConfigurable.displayName=ProxyAI: Advanced Settings
 advancedSettingsConfigurable.proxy.title=HTTP/SOCKS Proxy
 advancedSettingsConfigurable.proxy.typeComboBoxField.label=Proxy:

--- a/src/main/resources/messages/codegpt.properties
+++ b/src/main/resources/messages/codegpt.properties
@@ -39,6 +39,7 @@ settings.displayName=ProxyAI: Settings
 settings.openaiQuotaExceeded=OpenAI quota exceeded.
 settingsConfigurable.displayName.label=Display name:
 settingsConfigurable.service.label=Selected provider:
+settingsConfigurable.service.codeCompletion.label=Code completion provider:
 settingsConfigurable.service.codegpt.apiKey.comment=You can find the API key in your <a href="https://tryproxy.io/account">User settings</a>.
 settingsConfigurable.service.codegpt.chatCompletionModel.comment=Choose a model optimized for conversational interactions, including assistance with general queries and explanations.
 settingsConfigurable.service.codegpt.codeCompletionModel.comment=Choose a model tailored for code completion-related tasks.

--- a/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionServiceTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionServiceTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.testFramework.PlatformTestUtil
 import ee.carlrobert.codegpt.CodeGPTKeys.REMAINING_EDITOR_COMPLETION
 import ee.carlrobert.codegpt.settings.configuration.ConfigurationSettings
+import ee.carlrobert.codegpt.settings.service.ModelRole.*
 import ee.carlrobert.codegpt.settings.service.codegpt.CodeGPTServiceSettings
 import ee.carlrobert.codegpt.util.file.FileUtil
 import ee.carlrobert.llm.client.http.RequestEntity
@@ -18,7 +19,7 @@ import testsupport.IntegrationTest
 class CodeCompletionServiceTest : IntegrationTest() {
 
     fun `test code completion with ProxyAI provider`() {
-        useCodeGPTService()
+        useCodeGPTService(CODECOMPLETION_ROLE)
         service<CodeGPTServiceSettings>().state.nextEditsEnabled = false
         myFixture.configureByText(
             "CompletionTest.java",
@@ -58,7 +59,7 @@ class CodeCompletionServiceTest : IntegrationTest() {
     }
 
     fun `test code completion with OpenAI provider`() {
-        useOpenAIService()
+        useOpenAIService("gpt-4", CODECOMPLETION_ROLE)
         service<CodeGPTServiceSettings>().state.nextEditsEnabled = false
         myFixture.configureByText(
             "CompletionTest.java",
@@ -98,7 +99,7 @@ class CodeCompletionServiceTest : IntegrationTest() {
     }
 
     fun `test apply next partial completion word`() {
-        useLlamaService(true)
+        useLlamaService(true, CODECOMPLETION_ROLE)
         service<CodeGPTServiceSettings>().state.nextEditsEnabled = false
         myFixture.configureByText(
             "CompletionTest.java",
@@ -153,7 +154,7 @@ class CodeCompletionServiceTest : IntegrationTest() {
     }
 
     fun `_test apply inline suggestions without initial following text`() {
-        useCodeGPTService()
+        useCodeGPTService(CODECOMPLETION_ROLE)
         service<CodeGPTServiceSettings>().state.nextEditsEnabled = false
         myFixture.configureByText(
             "CompletionTest.java",
@@ -270,7 +271,7 @@ class CodeCompletionServiceTest : IntegrationTest() {
     }
 
     fun `_test apply inline suggestions with initial following text`() {
-        useCodeGPTService()
+        useCodeGPTService(CODECOMPLETION_ROLE)
         service<CodeGPTServiceSettings>().state.nextEditsEnabled = false
         myFixture.configureByText(
             "CompletionTest.java",
@@ -341,7 +342,7 @@ class CodeCompletionServiceTest : IntegrationTest() {
     }
 
     fun `_test adjust completion line whitespaces`() {
-        useCodeGPTService()
+        useCodeGPTService(CODECOMPLETION_ROLE)
         service<CodeGPTServiceSettings>().state.nextEditsEnabled = false
         myFixture.configureByText(
             "CompletionTest.java",

--- a/src/test/kotlin/testsupport/mixin/ShortcutsTestMixin.kt
+++ b/src/test/kotlin/testsupport/mixin/ShortcutsTestMixin.kt
@@ -60,6 +60,9 @@ interface ShortcutsTestMixin {
     setCredential(OllamaApikey, "TEST_API_KEY")
     service<OllamaSettings>().state.apply {
       model = HuggingFaceModel.LLAMA_3_8B_Q6_K.code
+      codeCompletionModel = HuggingFaceModel.CODE_QWEN_2_5_3B_Q4_K_M.code
+      codeCompletionsEnabled = true
+      fimOverride = false
       host = null
     }
   }

--- a/src/test/kotlin/testsupport/mixin/ShortcutsTestMixin.kt
+++ b/src/test/kotlin/testsupport/mixin/ShortcutsTestMixin.kt
@@ -6,6 +6,8 @@ import ee.carlrobert.codegpt.completions.HuggingFaceModel
 import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.*
 import ee.carlrobert.codegpt.credentials.CredentialsStore.setCredential
 import ee.carlrobert.codegpt.settings.GeneralSettings
+import ee.carlrobert.codegpt.settings.service.ModelRole
+import ee.carlrobert.codegpt.settings.service.ModelRole.*
 import ee.carlrobert.codegpt.settings.service.ServiceType
 import ee.carlrobert.codegpt.settings.service.azure.AzureSettings
 import ee.carlrobert.codegpt.settings.service.codegpt.CodeGPTServiceSettings
@@ -18,8 +20,8 @@ import java.util.function.BooleanSupplier
 
 interface ShortcutsTestMixin {
 
-  fun useCodeGPTService() {
-    service<GeneralSettings>().state.selectedService = ServiceType.CODEGPT
+  fun useCodeGPTService(role: ModelRole = CHAT_ROLE) {
+    service<GeneralSettings>().state.setSelectedService(role,ServiceType.CODEGPT)
     setCredential(CodeGptApiKey, "TEST_API_KEY")
     service<CodeGPTServiceSettings>().state.run {
       chatCompletionSettings.model = "TEST_MODEL"
@@ -28,8 +30,8 @@ interface ShortcutsTestMixin {
     }
   }
 
-  fun useOpenAIService(chatModel: String? = "gpt-4") {
-    service<GeneralSettings>().state.selectedService = ServiceType.OPENAI
+  fun useOpenAIService(chatModel: String? = "gpt-4", role: ModelRole = CHAT_ROLE) {
+    service<GeneralSettings>().state.setSelectedService(role, ServiceType.OPENAI)
     setCredential(OpenaiApiKey, "TEST_API_KEY")
     service<OpenAISettings>().state.run {
       model = chatModel
@@ -37,8 +39,8 @@ interface ShortcutsTestMixin {
     }
   }
 
-  fun useAzureService() {
-    GeneralSettings.getCurrentState().selectedService = ServiceType.AZURE
+  fun useAzureService(role: ModelRole = CHAT_ROLE) {
+    GeneralSettings.getCurrentState().setSelectedService(role, ServiceType.AZURE)
     setCredential(AzureOpenaiApiKey, "TEST_API_KEY")
     val azureSettings = AzureSettings.getCurrentState()
     azureSettings.resourceName = "TEST_RESOURCE_NAME"
@@ -46,15 +48,15 @@ interface ShortcutsTestMixin {
     azureSettings.deploymentId = "TEST_DEPLOYMENT_ID"
   }
 
-  fun useLlamaService(codeCompletionsEnabled: Boolean = false) {
-    GeneralSettings.getCurrentState().selectedService = ServiceType.LLAMA_CPP
+  fun useLlamaService(codeCompletionsEnabled: Boolean = false, role: ModelRole = CHAT_ROLE) {
+    GeneralSettings.getCurrentState().setSelectedService(role,ServiceType.LLAMA_CPP)
     LlamaSettings.getCurrentState().serverPort = null
     LlamaSettings.getCurrentState().isCodeCompletionsEnabled = codeCompletionsEnabled
     LlamaSettings.getCurrentState().huggingFaceModel = HuggingFaceModel.CODE_LLAMA_7B_Q4
   }
 
-  fun useOllamaService() {
-    GeneralSettings.getCurrentState().selectedService = ServiceType.OLLAMA
+  fun useOllamaService(role: ModelRole = CHAT_ROLE) {
+    GeneralSettings.getCurrentState().setSelectedService(role, ServiceType.OLLAMA)
     setCredential(OllamaApikey, "TEST_API_KEY")
     service<OllamaSettings>().state.apply {
       model = HuggingFaceModel.LLAMA_3_8B_Q6_K.code
@@ -62,8 +64,8 @@ interface ShortcutsTestMixin {
     }
   }
 
-  fun useGoogleService() {
-    GeneralSettings.getCurrentState().selectedService = ServiceType.GOOGLE
+  fun useGoogleService(role: ModelRole = CHAT_ROLE) {
+    GeneralSettings.getCurrentState().setSelectedService(role, ServiceType.GOOGLE)
     setCredential(GoogleApiKey, "TEST_API_KEY")
     service<GoogleSettings>().state.model = GoogleModel.GEMINI_PRO.code
   }


### PR DESCRIPTION
Add separate settings for code completion model: 

- Separate selection of model provider for code completion to use different providers for chat and code completion (for example to use ProxyAI model for chat and other actions + local code completion)
- Separate Ollama model selection for code completion

This pull request closes issues #733, #804 and #1025.

Also during addition of the test for new Ollama model selection, I have found a bug in code completion tests: code completion cache (`CodeCompletionCacheService`) was not resetted between tests. As I used different model responce for same input (`rivate void main` instead of `ublic void main` in other tests), next executed tests (`test code completion with OpenAI provider` and `test code completion with ProxyAI provider`) became failed. To fix this bug I have added cleaning of `CodeCompletionCacheService` to each test.

This bug most likely led that some of the other tests did not work: actually that tests was tested code completion cache instead of real model query code. So after my fix this tests will start working as expected.