### PR TITLE
fix: Remove YouSettings application service from plugin.xml

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -70,7 +70,6 @@
         <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.GeneralSettings"/>
         <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.service.anthropic.AnthropicSettings"/>
         <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.service.openai.OpenAISettings"/>
-        <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.service.you.YouSettings"/>
         <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.service.mistral.MistralSettings"/>
         <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.service.llama.LlamaSettings"/>
         <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.service.ollama.OllamaSettings"/>


### PR DESCRIPTION
The class `ee.carlrobert.codegpt.settings.service.you.YouSettings` was removed in an earlier commit, but was still referenced in the `plugin.xml`.

This caused an error every now and then.