### PR TITLE
fix: Custom Open AI services do not adhere to model selections

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/actions/CodeCompletionFeatureToggleActions.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/actions/CodeCompletionFeatureToggleActions.kt
@@ -40,8 +40,9 @@ abstract class CodeCompletionFeatureToggleActions(
             }
 
             CUSTOM_OPENAI -> {
-                service<CustomServicesSettings>().state.active.codeCompletionSettings.codeCompletionsEnabled =
-                    enableFeatureAction
+                service<CustomServicesSettings>()
+                    .customServiceStateForFeatureType(FeatureType.CODE_COMPLETION)
+                    .codeCompletionSettings.codeCompletionsEnabled = enableFeatureAction
             }
 
             ANTHROPIC,

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionRequestFactory.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionRequestFactory.kt
@@ -54,7 +54,8 @@ object CodeCompletionRequestFactory {
 
     @JvmStatic
     fun buildCustomRequest(details: InfillRequest): Request {
-        val activeService = service<CustomServicesSettings>().state.active
+        val activeService = service<CustomServicesSettings>()
+            .customServiceStateForFeatureType(FeatureType.CODE_COMPLETION)
         val settings = activeService.codeCompletionSettings
         val credential =
             getCredential(CredentialKey.CustomServiceApiKey(activeService.name.orEmpty()))

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/DebouncedCodeCompletionProvider.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/DebouncedCodeCompletionProvider.kt
@@ -109,7 +109,10 @@ class DebouncedCodeCompletionProvider : DebouncedInlineCompletionProvider() {
         val codeCompletionsEnabled = when (selectedService) {
             ServiceType.PROXYAI -> service<CodeGPTServiceSettings>().state.codeCompletionSettings.codeCompletionsEnabled
             ServiceType.OPENAI -> OpenAISettings.getCurrentState().isCodeCompletionsEnabled
-            ServiceType.CUSTOM_OPENAI -> service<CustomServicesSettings>().state.active.codeCompletionSettings.codeCompletionsEnabled
+            ServiceType.CUSTOM_OPENAI -> service<CustomServicesSettings>()
+                .customServiceStateForFeatureType(FeatureType.CODE_COMPLETION)
+                .codeCompletionSettings.codeCompletionsEnabled
+
             ServiceType.LLAMA_CPP -> LlamaSettings.isCodeCompletionsPossible()
             ServiceType.OLLAMA -> service<OllamaSettings>().state.codeCompletionsEnabled
             ServiceType.MISTRAL -> true  // Mistral supports code completions

--- a/src/main/kotlin/ee/carlrobert/codegpt/completions/factory/CustomOpenAIRequestFactory.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/completions/factory/CustomOpenAIRequestFactory.kt
@@ -21,11 +21,9 @@ class CustomOpenAIRequest(val request: Request) : CompletionRequest
 class CustomOpenAIRequestFactory : BaseRequestFactory() {
 
     override fun createChatRequest(params: ChatCompletionParameters): CustomOpenAIRequest {
-        val activeService = service<CustomServicesSettings>()
-            .state
-            .active
+        val service = service<CustomServicesSettings>().customServiceStateForFeatureType(FeatureType.CHAT)
         val request = buildCustomOpenAIChatCompletionRequest(
-            activeService.chatCompletionSettings,
+            service.chatCompletionSettings,
             OpenAIRequestFactory.buildOpenAIMessages(
                 null,
                 params,
@@ -34,7 +32,7 @@ class CustomOpenAIRequestFactory : BaseRequestFactory() {
                 params.psiStructure
             ),
             true,
-            getCredential(CredentialKey.CustomServiceApiKey(activeService.name.orEmpty()))
+            getCredential(CredentialKey.CustomServiceApiKey(service.name.orEmpty()))
         )
         return CustomOpenAIRequest(request)
     }
@@ -46,18 +44,16 @@ class CustomOpenAIRequestFactory : BaseRequestFactory() {
         stream: Boolean,
         featureType: FeatureType
     ): CompletionRequest {
-        val activeService = service<CustomServicesSettings>()
-            .state
-            .active
+        val service = service<CustomServicesSettings>().customServiceStateForFeatureType(featureType)
 
         val request = buildCustomOpenAIChatCompletionRequest(
-            activeService.chatCompletionSettings,
+            service.chatCompletionSettings,
             listOf(
                 OpenAIChatCompletionStandardMessage("system", systemPrompt),
                 OpenAIChatCompletionStandardMessage("user", userPrompt)
             ),
             stream,
-            getCredential(CredentialKey.CustomServiceApiKey(activeService.name.orEmpty()))
+            getCredential(CredentialKey.CustomServiceApiKey(service.name.orEmpty()))
         )
         return CustomOpenAIRequest(request)
     }


### PR DESCRIPTION
Fixes #1089 

My (second) hunch was correct. The `CustomOpenAIRequestFactory` as well as several points in the Code Completion logic referenced `ee.carlrobert.codegpt.settings.service.custom.CustomServicesState#getActive` but that property always contains the same (first) custom service definition state.