### PR TITLE
feat: chat-based FIM code completion for Custom OpenAI providers

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/InfillPromptTemplate.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/InfillPromptTemplate.kt
@@ -155,6 +155,13 @@ enum class InfillPromptTemplate(val label: String, val stopTokens: List<String>?
                 "[SUFFIX]${infillDetails.suffix}[PREFIX]${infillDetails.prefix}[MIDDLE]"
             return createDefaultMultiFilePrompt(infillDetails, infillPrompt)
         }
+    },
+    CHAT_COMPLETION("Chat-based FIM", listOf("\n\n", "```")) {
+        override fun buildPrompt(infillDetails: InfillRequest): String {
+            // This template is used for chat-based FIM completion
+            // The actual prompt construction is handled in the request factory
+            return "CHAT_FIM_PLACEHOLDER"
+        }
     };
 
     abstract fun buildPrompt(infillDetails: InfillRequest): String

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/form/CustomServiceCodeCompletionForm.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/form/CustomServiceCodeCompletionForm.kt
@@ -162,17 +162,34 @@ class CustomServiceCodeCompletionForm(
     }
 
     private fun testConnection() {
-        CompletionRequestService.getInstance().getCustomOpenAICompletionAsync(
-            CodeCompletionRequestFactory.buildCustomRequest(
-                InfillRequest.Builder("Hello", "!", 0).build(),
-                urlField.text,
-                tabbedPane.headers,
-                tabbedPane.body,
-                promptTemplateComboBox.selectedItem as InfillPromptTemplate,
-                getApiKey.invoke()
-            ),
-            TestConnectionEventListener()
-        )
+        val selectedTemplate = promptTemplateComboBox.selectedItem as InfillPromptTemplate
+        val testRequest = InfillRequest.Builder("Hello", "!", 0).build()
+        
+        if (selectedTemplate == InfillPromptTemplate.CHAT_COMPLETION) {
+            // Use chat completion endpoint for testing
+            CompletionRequestService.getInstance().getCustomOpenAIChatCompletionAsync(
+                CodeCompletionRequestFactory.buildChatBasedFIMHttpRequest(
+                    testRequest,
+                    urlField.text,
+                    tabbedPane.headers,
+                    getApiKey.invoke()
+                ),
+                TestConnectionEventListener()
+            )
+        } else {
+            // Use traditional completion endpoint for testing
+            CompletionRequestService.getInstance().getCustomOpenAICompletionAsync(
+                CodeCompletionRequestFactory.buildCustomRequest(
+                    testRequest,
+                    urlField.text,
+                    tabbedPane.headers,
+                    tabbedPane.body,
+                    selectedTemplate,
+                    getApiKey.invoke()
+                ),
+                TestConnectionEventListener()
+            )
+        }
     }
 
     internal inner class TestConnectionEventListener : CompletionEventListener<String?> {

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/form/CustomServiceCodeCompletionForm.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/form/CustomServiceCodeCompletionForm.kt
@@ -172,6 +172,7 @@ class CustomServiceCodeCompletionForm(
                     testRequest,
                     urlField.text,
                     tabbedPane.headers,
+                    tabbedPane.body,
                     getApiKey.invoke()
                 ),
                 TestConnectionEventListener()

--- a/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/ChatBasedFIMTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/ChatBasedFIMTest.kt
@@ -40,18 +40,18 @@ class ChatBasedFIMTest {
         assertNotNull(chatRequest)
         assertEquals(2, chatRequest.messages.size)
         
-        val systemMessage = chatRequest.messages[0]
+        val systemMessage = chatRequest.messages[0] as OpenAIChatCompletionStandardMessage
         assertEquals("system", systemMessage.role)
         assertTrue(systemMessage.content.contains("expert coding assistant"))
         
-        val userMessage = chatRequest.messages[1]
+        val userMessage = chatRequest.messages[1] as OpenAIChatCompletionStandardMessage
         assertEquals("user", userMessage.role)
         assertTrue(userMessage.content.contains("PREFIX:"))
         assertTrue(userMessage.content.contains("SUFFIX:"))
         assertTrue(userMessage.content.contains("function calculateSum(a, b) {"))
         assertTrue(userMessage.content.contains("return result;"))
         
-        assertTrue(chatRequest.stream)
+        assertTrue(chatRequest.isStream)
         assertEquals(128, chatRequest.maxTokens)
         assertEquals(0.0, chatRequest.temperature)
     }

--- a/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/ChatBasedFIMTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/ChatBasedFIMTest.kt
@@ -2,7 +2,7 @@ package ee.carlrobert.codegpt.codecompletions
 
 import ee.carlrobert.codegpt.settings.service.FeatureType
 import ee.carlrobert.codegpt.settings.service.ModelSelectionService
-import ee.carlrobert.llm.client.openai.completion.ChatMessage
+import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionStandardMessage
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 
@@ -76,11 +76,18 @@ class ChatBasedFIMTest {
     fun `test chat based FIM HTTP request creation`() {
         val infillRequest = InfillRequest.Builder("test prefix", "test suffix", 0).build()
         val headers = mapOf("Authorization" to "Bearer \$CUSTOM_SERVICE_API_KEY")
+        val body = mapOf<String, Any>(
+            "model" to "gpt-4.1",
+            "temperature" to 0.2,
+            "max_tokens" to 24,
+            "stream" to false
+        )
         
         val httpRequest = CodeCompletionRequestFactory.buildChatBasedFIMHttpRequest(
             infillRequest,
             "https://api.openai.com/v1/chat/completions",
             headers,
+            body,
             "test-api-key"
         )
         

--- a/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/ChatBasedFIMTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/ChatBasedFIMTest.kt
@@ -1,0 +1,92 @@
+package ee.carlrobert.codegpt.codecompletions
+
+import ee.carlrobert.codegpt.settings.service.FeatureType
+import ee.carlrobert.codegpt.settings.service.ModelSelectionService
+import ee.carlrobert.llm.client.openai.completion.ChatMessage
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+class ChatBasedFIMTest {
+
+    @Test
+    fun `test chat completion template is available`() {
+        val templates = InfillPromptTemplate.values()
+        val chatTemplate = templates.find { it == InfillPromptTemplate.CHAT_COMPLETION }
+        
+        assertNotNull(chatTemplate)
+        assertEquals("Chat-based FIM", chatTemplate?.label)
+        assertEquals(listOf("\n\n", "```"), chatTemplate?.stopTokens)
+    }
+
+    @Test
+    fun `test chat completion template builds placeholder`() {
+        val template = InfillPromptTemplate.CHAT_COMPLETION
+        val infillRequest = InfillRequest.Builder("function test() {", "}", 0).build()
+        
+        val result = template.buildPrompt(infillRequest)
+        assertEquals("CHAT_FIM_PLACEHOLDER", result)
+    }
+
+    @Test
+    fun `test chat based FIM request creation`() {
+        val infillRequest = InfillRequest.Builder(
+            "function calculateSum(a, b) {",
+            "return result;\n}",
+            0
+        ).build()
+        
+        val chatRequest = CodeCompletionRequestFactory.buildChatBasedFIMRequest(infillRequest)
+        
+        assertNotNull(chatRequest)
+        assertEquals(2, chatRequest.messages.size)
+        
+        val systemMessage = chatRequest.messages[0]
+        assertEquals("system", systemMessage.role)
+        assertTrue(systemMessage.content.contains("expert coding assistant"))
+        
+        val userMessage = chatRequest.messages[1]
+        assertEquals("user", userMessage.role)
+        assertTrue(userMessage.content.contains("PREFIX:"))
+        assertTrue(userMessage.content.contains("SUFFIX:"))
+        assertTrue(userMessage.content.contains("function calculateSum(a, b) {"))
+        assertTrue(userMessage.content.contains("return result;"))
+        
+        assertTrue(chatRequest.stream)
+        assertEquals(128, chatRequest.maxTokens)
+        assertEquals(0.0, chatRequest.temperature)
+    }
+
+    @Test
+    fun `test custom request throws exception for chat completion template`() {
+        val infillRequest = InfillRequest.Builder("test", "test", 0).build()
+        
+        assertThrows(IllegalArgumentException::class.java) {
+            CodeCompletionRequestFactory.buildCustomRequest(
+                infillRequest,
+                "http://test.com",
+                emptyMap(),
+                emptyMap(),
+                InfillPromptTemplate.CHAT_COMPLETION,
+                null
+            )
+        }
+    }
+
+    @Test
+    fun `test chat based FIM HTTP request creation`() {
+        val infillRequest = InfillRequest.Builder("test prefix", "test suffix", 0).build()
+        val headers = mapOf("Authorization" to "Bearer \$CUSTOM_SERVICE_API_KEY")
+        
+        val httpRequest = CodeCompletionRequestFactory.buildChatBasedFIMHttpRequest(
+            infillRequest,
+            "https://api.openai.com/v1/chat/completions",
+            headers,
+            "test-api-key"
+        )
+        
+        assertNotNull(httpRequest)
+        assertEquals("https://api.openai.com/v1/chat/completions", httpRequest.url.toString())
+        assertEquals("Bearer test-api-key", httpRequest.header("Authorization"))
+        assertEquals("application/json", httpRequest.body?.contentType()?.toString())
+    }
+}


### PR DESCRIPTION
@carlrobertoh: this is the only feature missing in ProxyAI to finally ditch Github Copilot!

FIM Code completion is done in ProxyAI using gpt-3.5-turbo-instruct via the `/v1/completions` endpoint only which is now [legacy](https://platform.openai.com/docs/guides/completions). Many OpenAI-compatible APIs do not support this endpoint.

I added Chat-based FIM code completion and tested with gpt-4.1.

May conflict with: https://github.com/carlrobertoh/ProxyAI/pull/1090, I could rebase if necessary.

<img width="1188" height="842" alt="Screenshot_20250818_130647" src="https://github.com/user-attachments/assets/4d688c29-06b9-4223-9980-b789757cf45d" />

Sample GPT-4.1 chat completion:

<img width="741" height="478" alt="Screenshot_20250821_114946" src="https://github.com/user-attachments/assets/4e635b0e-6019-45a0-b401-acc63c8dd3e6" />